### PR TITLE
chore: release on chore commits as well

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -34,7 +34,7 @@
         "RELEASETAG": "dist/releasetag.txt",
         "RELEASE_TAG_PREFIX": "",
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
-        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\""
+        "RELEASABLE_COMMITS": "git log --oneline $LATEST_TAG..HEAD"
       },
       "steps": [
         {
@@ -323,7 +323,7 @@
         "RELEASETAG": "dist/releasetag.txt",
         "RELEASE_TAG_PREFIX": "",
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
-        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\""
+        "RELEASABLE_COMMITS": "git log --oneline $LATEST_TAG..HEAD"
       },
       "steps": [
         {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,5 +1,6 @@
 import { CdklabsConstructLibrary, JsiiLanguage } from 'cdklabs-projen-project-types';
 import { NodePackageManager, UpgradeDependenciesSchedule } from 'projen/lib/javascript';
+import { ReleasableCommits } from 'projen/lib/version';
 
 const project = new CdklabsConstructLibrary({
   private: false,
@@ -51,7 +52,8 @@ const project = new CdklabsConstructLibrary({
       schedule: UpgradeDependenciesSchedule.MONTHLY,
     },
   },
-  description: 'Build during CDK deployment.',
+  releasableCommits: ReleasableCommits.everyCommit(),
+  description: 'Run build on CDK deployment time.',
   jsiiTargetLanguages: [JsiiLanguage.PYTHON, JsiiLanguage.JAVA],
 });
 project.eslint?.addRules({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdklabs/deploy-time-build",
-  "description": "Build during CDK deployment.",
+  "description": "Run build on CDK deployment time.",
   "repository": {
     "type": "git",
     "url": "https://github.com/cdklabs/deploy-time-build.git"


### PR DESCRIPTION
Now that #48 reduced the frequency of chore commits (dep-upgrade), we release on every commits including chore.